### PR TITLE
Add Capability to Create and Upsert Cloud Resource Entities

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ def main():
             'port_client_secret': os.environ["PORT_CLIENT_SECRET"],
             'port_base_url': os.getenv("PORT_BASE_URL", "https://api.getport.io/v1"),
             'port_blueprint': os.getenv("PORT_BLUEPRINT", "awsCost"),
+            'port_cloud_resource_blueprint': os.getenv("PORT_CLOUD_RESOURCE_BLUEPRINT", "cloudResource"),
             'port_max_workers': int(os.getenv("PORT_MAX_WORKERS", "5")),
             'port_months_to_keep': int(os.getenv("PORT_MONTHS_TO_KEEP", "3")),
             'aws_bucket_name': os.environ["AWS_BUCKET_NAME"],

--- a/port/entities.py
+++ b/port/entities.py
@@ -16,6 +16,18 @@ def build_cost_entity(report_data, blueprint):
             entity["properties"]["blendedCost"] += float(line.get("lineItem/BlendedCost", 0))
             entity["properties"]["amortizedCost"] += _calc_amortized_cost(line)
             entity["properties"]["ondemandCost"] += float(line.get("pricing/publicOnDemandCost", 0))
+
+        arn = (
+            identifier.split("@")[0][len("arn:") :]
+            if identifier.startswith("arn:")
+            else None
+        )
+
+        if arn:
+            # add relation
+            entity["relations"] = {
+                "cloud-resource": lines[0]["lineItem/ResourceId"]
+            }
         yield entity
 
 def build_cloud_resource_entity(data, blueprint):


### PR DESCRIPTION
1. **Add Capability to Create and Upsert Cloud Resource Entities:**
   - Introduces the `build_cloud_resource_entity` function for extracting relevant data and constructing cloud resource entities.

2. **Add Relation to Cloud Resource on AWS Cost Blueprint:**
   - Extends the AWS Cost blueprint with a new feature to add relations to cloud resources.
   
  This PR updates the resources used in the [guide](https://github.com/port-labs/port-docs/pull/968)
